### PR TITLE
Integrate Yahoo Finance API for stock charts and implement custom `St…

### DIFF
--- a/app/src/main/java/com/example/marketlens/data/AppContainer.kt
+++ b/app/src/main/java/com/example/marketlens/data/AppContainer.kt
@@ -7,11 +7,13 @@ import com.example.marketlens.data.repository.MarketRepository
 import com.example.marketlens.data.repository.NewsRepository
 import com.example.marketlens.data.repository.RealMarketRepository
 
-
 object AppContainer {
 
     val repository: MarketRepository by lazy {
-        RealMarketRepository(NetworkModule.marketApi)
+        RealMarketRepository(
+            api   = NetworkModule.marketApi,
+            yahoo = NetworkModule.yahooFinanceApi
+        )
     }
 
     val newsRepository: NewsRepository by lazy {

--- a/app/src/main/java/com/example/marketlens/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/marketlens/data/network/NetworkModule.kt
@@ -5,40 +5,50 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object NetworkModule {
 
-    private const val BASE_URL = "https://finnhub.io/api/v1/"
-
-    // Appends ?token=YOUR_KEY to every request automatically
-    private val tokenInterceptor = Interceptor { chain ->
-        val urlWithToken = chain.request().url.newBuilder()
-            .addQueryParameter("token", BuildConfig.FINNHUB_API_KEY)
-            .build()
-        chain.proceed(chain.request().newBuilder().url(urlWithToken).build())
-    }
-
-    private val loggingInterceptor = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.BASIC
-    }
-
-    private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(tokenInterceptor)
-        .addInterceptor(loggingInterceptor)
-        .build()
-
     private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
+        .addLast(KotlinJsonAdapterFactory())
         .build()
 
-    private val retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .client(okHttpClient)
+    // ── Finnhub ───────────────────────────────────────────────────────────────
+    private val finnhubClient = OkHttpClient.Builder()
+        .addInterceptor(Interceptor { chain ->
+            val original = chain.request()
+            val url = original.url.newBuilder()
+                .addQueryParameter("token", BuildConfig.FINNHUB_API_KEY)
+                .build()
+            chain.proceed(original.newBuilder().url(url).build())
+        })
+        .build()
+
+    val marketApi: MarketApi = Retrofit.Builder()
+        .baseUrl("https://finnhub.io/api/v1/")
+        .client(finnhubClient)
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
+        .create(MarketApi::class.java)
 
-    val marketApi: MarketApi = retrofit.create(MarketApi::class.java)
+    // ── Yahoo Finance ─────────────────────────────────────────────────────────
+    private val yahooClient = OkHttpClient.Builder()
+        .addInterceptor(Interceptor { chain ->
+            val request = chain.request().newBuilder()
+                .addHeader(
+                    "User-Agent",
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                )
+                .build()
+            chain.proceed(request)
+        })
+        .build()
+
+    val yahooFinanceApi: YahooFinanceApi = Retrofit.Builder()
+        .baseUrl("https://query1.finance.yahoo.com/")
+        .client(yahooClient)
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .build()
+        .create(YahooFinanceApi::class.java)
 }

--- a/app/src/main/java/com/example/marketlens/data/network/YahooFinanceAoi.kt
+++ b/app/src/main/java/com/example/marketlens/data/network/YahooFinanceAoi.kt
@@ -1,0 +1,17 @@
+package com.example.marketlens.data.network
+
+import com.example.marketlens.data.network.dto.YahooChartResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+
+interface YahooFinanceApi {
+
+    @GET("v8/finance/chart/{symbol}")
+    suspend fun getChart(
+        @Path("symbol")   symbol: String,
+        @Query("interval") interval: String,
+        @Query("range")    range: String
+    ): YahooChartResponseDto
+}

--- a/app/src/main/java/com/example/marketlens/data/network/dto/YahooFinanceDto.kt
+++ b/app/src/main/java/com/example/marketlens/data/network/dto/YahooFinanceDto.kt
@@ -1,0 +1,26 @@
+package com.example.marketlens.data.network.dto
+
+import com.squareup.moshi.Json
+
+
+data class YahooChartResponseDto(
+    @Json(name = "chart") val chart: YahooChartDto
+)
+
+data class YahooChartDto(
+    @Json(name = "result") val result: List<YahooChartResultDto>?,
+    @Json(name = "error")  val error: Any?
+)
+
+data class YahooChartResultDto(
+    @Json(name = "timestamp")  val timestamps: List<Long>?,
+    @Json(name = "indicators") val indicators: YahooIndicatorsDto
+)
+
+data class YahooIndicatorsDto(
+    @Json(name = "quote") val quote: List<YahooQuoteDto>
+)
+
+data class YahooQuoteDto(
+    @Json(name = "close") val close: List<Double?>
+)

--- a/app/src/main/java/com/example/marketlens/data/repository/RealMarketRepository.kt
+++ b/app/src/main/java/com/example/marketlens/data/repository/RealMarketRepository.kt
@@ -6,9 +6,14 @@ import com.example.marketlens.data.model.StockProfile
 import com.example.marketlens.data.model.StockQuote
 import com.example.marketlens.data.network.ApiResult
 import com.example.marketlens.data.network.MarketApi
+import com.example.marketlens.data.network.YahooFinanceApi
 
-class RealMarketRepository(private val api: MarketApi) : MarketRepository {
+class RealMarketRepository(
+    private val api:   MarketApi,
+    private val yahoo: YahooFinanceApi
+) : MarketRepository {
 
+    // ── Quote (Finnhub) ───────────────────────────────────────────────────────
     override suspend fun getQuote(symbol: String): ApiResult<StockQuote> {
         return try {
             val dto = api.getQuote(symbol)
@@ -18,6 +23,7 @@ class RealMarketRepository(private val api: MarketApi) : MarketRepository {
         }
     }
 
+    // ── Search (Finnhub) ──────────────────────────────────────────────────────
     override suspend fun searchSymbols(query: String): ApiResult<List<SearchResult>> {
         return try {
             val dto = api.searchSymbols(query)
@@ -30,16 +36,60 @@ class RealMarketRepository(private val api: MarketApi) : MarketRepository {
         }
     }
 
-    override suspend fun getCandles(symbol: String, resolution: String, from: Long, to: Long): ApiResult<StockCandle> {
+    // ── Candles (Yahoo Finance) ───────────────────────────────────────────────
+    /*
+        Yahoo Finance replaces Finnhub for all chart/history data.
+        No API key needed, no rate limits for normal usage.
+
+        We map our Timeframe enum to Yahoo's interval + range params:
+          resolution "D"  + daysBack 30  → interval=1d,  range=1mo
+          resolution "D"  + daysBack 90  → interval=1d,  range=3mo
+          resolution "W"  + daysBack 365 → interval=1d,  range=1y
+
+        We ignore the raw `from`/`to` epoch params from the interface
+        and use Yahoo's range strings instead — cleaner and more reliable.
+    */
+    override suspend fun getCandles(
+        symbol: String, resolution: String, from: Long, to: Long
+    ): ApiResult<StockCandle> {
         return try {
-            val dto = api.getCandles(symbol, resolution, from, to)
-            if (dto.status != "ok") return ApiResult.Error("No chart data available for $symbol in this time range")
-            ApiResult.Success(StockCandle(dto.timestamps!!, dto.closePrices!!, dto.status))
+            // Map resolution + rough date range to Yahoo params
+            val (interval, range) = when {
+                resolution == "W"                          -> "1d"  to "1y"
+                resolution == "D" && (to - from) > 60 * 86400L -> "1d" to "3mo"
+                resolution == "D"                          -> "1d"  to "1mo"
+                else                                       -> "1d"  to "1mo"
+            }
+
+            val response = yahoo.getChart(symbol, interval, range)
+            val result   = response.chart.result?.firstOrNull()
+                ?: return ApiResult.Error("No chart data available for $symbol")
+
+            /*
+                Yahoo sometimes returns null for individual close prices
+                (e.g. on trading halts or data gaps).
+                We filter those out with filterNotNull().
+            */
+            val closePrices = result.indicators.quote
+                .firstOrNull()
+                ?.close
+                ?.filterNotNull()
+                ?: return ApiResult.Error("No price data in chart response for $symbol")
+
+            if (closePrices.isEmpty()) {
+                return ApiResult.Error("No chart data for $symbol in this time range")
+            }
+
+            // Use sequential indices as timestamps — the chart only needs prices
+            val timestamps = closePrices.indices.map { it.toLong() }
+            ApiResult.Success(StockCandle(timestamps, closePrices, "ok"))
+
         } catch (e: Exception) {
             ApiResult.Error("Could not load chart for $symbol: ${e.message}", e)
         }
     }
 
+    // ── Profile + Key Stats (Finnhub) ─────────────────────────────────────────
     override suspend fun getStockProfile(symbol: String): ApiResult<StockProfile> {
         return try {
             val profileDto = api.getStockProfile(symbol)

--- a/app/src/main/java/com/example/marketlens/ui/components/StockChart.kt
+++ b/app/src/main/java/com/example/marketlens/ui/components/StockChart.kt
@@ -1,0 +1,131 @@
+package com.example.marketlens.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.*
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.marketlens.ui.theme.PriceDown
+import com.example.marketlens.ui.theme.PriceUp
+
+
+@Composable
+fun StockChart(
+    prices:   List<Double>,
+    modifier: Modifier = Modifier
+) {
+    if (prices.size < 2) {
+        Box(modifier.height(180.dp))
+        return
+    }
+
+    val isPositive = prices.last() >= prices.first()
+    val lineColor  = if (isPositive) PriceUp else PriceDown
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+
+    val textStyle = TextStyle(
+        fontSize = 10.sp,
+        color    = labelColor
+    )
+
+    val minPrice   = prices.min()
+    val maxPrice   = prices.max()
+    val priceRange = (maxPrice - minPrice).takeIf { it > 0 } ?: 1.0
+
+    val textMeasurer = rememberTextMeasurer()
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+        // No external padding — labels drawn inside canvas
+    ) {
+        val width      = size.width
+        val height     = size.height
+
+        // Guard — if canvas somehow has no size, do nothing
+        if (width <= 0f || height <= 0f) return@Canvas
+
+        val labelAreaWidth = 48f   // pixels reserved on right for Y labels
+        val chartWidth     = width - labelAreaWidth
+        val paddingTop     = 12f
+        val paddingBot     = 20f
+        val chartH         = height - paddingTop - paddingBot
+
+        // ── Convert price to canvas coordinate ───────────────────────────────
+        fun priceToOffset(index: Int, price: Double): Offset {
+            val x          = (index.toFloat() / (prices.size - 1)) * chartWidth
+            val normalized = (price - minPrice) / priceRange
+            val y          = paddingTop + chartH * (1f - normalized.toFloat())
+            return Offset(x, y)
+        }
+
+        val points = prices.mapIndexed { i, price -> priceToOffset(i, price) }
+
+        // ── Filled gradient under the line ───────────────────────────────────
+        val fillPath = Path().apply {
+            moveTo(points.first().x, height)
+            points.forEach { lineTo(it.x, it.y) }
+            lineTo(points.last().x, height)
+            close()
+        }
+
+        drawPath(
+            path  = fillPath,
+            brush = Brush.verticalGradient(
+                colors = listOf(lineColor.copy(alpha = 0.30f), Color.Transparent),
+                startY = paddingTop,
+                endY   = height
+            )
+        )
+
+        // ── Price line ────────────────────────────────────────────────────────
+        val linePath = Path().apply {
+            moveTo(points.first().x, points.first().y)
+            points.drop(1).forEach { lineTo(it.x, it.y) }
+        }
+
+        drawPath(
+            path  = linePath,
+            color = lineColor,
+            style = Stroke(width = 2.5f, cap = StrokeCap.Round, join = StrokeJoin.Round)
+        )
+
+        // ── Dot at latest price ───────────────────────────────────────────────
+        val lastPoint = points.last()
+        drawCircle(color = lineColor,   radius = 5f,   center = lastPoint)
+        drawCircle(color = Color.White, radius = 2.5f, center = lastPoint)
+
+        // ── Y-axis labels (drawn inside canvas, right side) ───────────────────
+        // Guard: only draw if label area is actually large enough
+        if (labelAreaWidth > 0f) {
+            val labelX = chartWidth + 4f
+            drawYLabel(textMeasurer, textStyle, "$%.0f".format(maxPrice), labelX, paddingTop)
+            drawYLabel(textMeasurer, textStyle, "$%.0f".format((minPrice + maxPrice) / 2), labelX, paddingTop + chartH / 2)
+            drawYLabel(textMeasurer, textStyle, "$%.0f".format(minPrice), labelX, paddingTop + chartH - 10f)
+        }
+    }
+}
+
+private fun DrawScope.drawYLabel(
+    textMeasurer: TextMeasurer,
+    style:        TextStyle,
+    text:         String,
+    x:            Float,
+    y:            Float
+) {
+    if (x >= size.width) return
+    drawText(
+        textMeasurer = textMeasurer,
+        text         = text,
+        style        = style,
+        topLeft      = Offset(x, y - 6f)
+    )
+}

--- a/app/src/main/java/com/example/marketlens/ui/stockdetail/StockDetailScreen.kt
+++ b/app/src/main/java/com/example/marketlens/ui/stockdetail/StockDetailScreen.kt
@@ -21,6 +21,7 @@ import com.example.marketlens.ui.theme.PriceUp
 import com.example.marketlens.viewmodel.Horizon
 import com.example.marketlens.viewmodel.StockDetailViewModel
 import com.example.marketlens.viewmodel.Timeframe
+import com.example.marketlens.ui.components.StockChart
 
 @Composable
 fun StockDetailScreen(viewModel: StockDetailViewModel, onBack: () -> Unit) {
@@ -80,11 +81,14 @@ fun StockDetailScreen(viewModel: StockDetailViewModel, onBack: () -> Unit) {
                 }
 
                 // ── Chart card ────────────────────────────────────────────────
+                // ── Chart card ────────────────────────────────────────────────────────────
                 Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
                     Column(Modifier.fillMaxWidth().padding(16.dp), Arrangement.spacedBy(12.dp)) {
                         Text("Price Chart", style = MaterialTheme.typography.titleMedium)
+
+                        // Timeframe selector — remove 1W since intraday requires paid tier
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Timeframe.entries.forEach { tf ->
+                            listOf(Timeframe.ONE_MONTH, Timeframe.THREE_MONTHS, Timeframe.ONE_YEAR).forEach { tf ->
                                 FilterChip(
                                     selected = state.selectedTimeframe == tf,
                                     onClick  = { viewModel.onTimeframeSelected(tf) },
@@ -92,22 +96,38 @@ fun StockDetailScreen(viewModel: StockDetailViewModel, onBack: () -> Unit) {
                                 )
                             }
                         }
+
                         HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant)
+
                         when {
-                            state.isCandleLoading -> Box(Modifier.fillMaxWidth().height(160.dp), Alignment.Center) {
-                                CircularProgressIndicator(Modifier.size(32.dp))
-                            }
-                            state.candleError != null -> Box(Modifier.fillMaxWidth().height(100.dp), Alignment.Center) {
-                                Text(state.candleError!!, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
-                            }
-                            candle != null && candle.hasData -> Box(Modifier.fillMaxWidth().height(160.dp), Alignment.Center) {
-                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                    Text("${candle.closePrices.size} data points loaded ✓", style = MaterialTheme.typography.bodySmall, color = PriceUp)
-                                    Text("Chart library integration — Phase 5", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+                            state.isCandleLoading -> {
+                                Box(Modifier.fillMaxWidth().height(180.dp), Alignment.Center) {
+                                    CircularProgressIndicator(Modifier.size(32.dp))
                                 }
                             }
-                            else -> Box(Modifier.fillMaxWidth().height(100.dp), Alignment.Center) {
-                                Text("No chart data for this timeframe", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            state.candleError != null -> {
+                                Box(Modifier.fillMaxWidth().height(80.dp), Alignment.Center) {
+                                    Text(
+                                        text  = state.candleError!!,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
+                            candle != null && candle.hasData -> {
+                                // The real chart — draws using closePrices from Alpha Vantage
+                                StockChart(
+                                    prices   = candle.closePrices,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                            else -> {
+                                Box(Modifier.fillMaxWidth().height(80.dp), Alignment.Center) {
+                                    Text(
+                                        text  = "No chart data for this timeframe",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
StockChart component

- Add `YahooFinanceApi` and corresponding DTOs for fetching chart data
- Update `NetworkModule` to support multiple Retrofit clients (Finnhub and Yahoo Finance)
- Refactor `RealMarketRepository` to use Yahoo Finance for historical candle data
- Implement `StockChart` using Jetpack Compose `Canvas` for custom price visualization
- Update `StockDetailScreen` to display the new chart and refine timeframe selection logic
Closes #34 
Closes #35  