### PR TITLE
Merge News and Signals screens into a tabbed interface

### DIFF
--- a/app/src/main/java/com/example/marketlens/navigation/AppScaffold.kt
+++ b/app/src/main/java/com/example/marketlens/navigation/AppScaffold.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -24,9 +23,7 @@ fun AppScaffold(navController: NavHostController, authViewModel: AuthViewModel) 
         AppRoute.Dashboard,
         AppRoute.Markets,
         AppRoute.News,
-        AppRoute.Watchlist,
-        AppRoute.Alerts,
-        AppRoute.Signals
+        AppRoute.Watchlist
     )
 
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -37,14 +34,15 @@ fun AppScaffold(navController: NavHostController, authViewModel: AuthViewModel) 
     Scaffold(
         topBar = {
             if (showTopBar) {
-                SignOutBar(
-                    userName      = authViewModel.currentUserName,
-                    showSettings  = currentRoute != AppRoute.Settings.route,
-                    onSignOut     = {
+                TopBar(
+                    userName        = authViewModel.currentUserName,
+                    showSettings    = currentRoute != AppRoute.Settings.route,
+                    onAlerts        = { navController.navigate(AppRoute.Alerts.route) },
+                    onSettings      = { navController.navigate(AppRoute.Settings.route) },
+                    onSignOut       = {
                         authViewModel.signOut()
                         navController.navigate(AppRoute.Auth.route) { popUpTo(0) { inclusive = true } }
-                    },
-                    onSettings    = { navController.navigate(AppRoute.Settings.route) }
+                    }
                 )
             }
         },
@@ -78,14 +76,27 @@ fun AppScaffold(navController: NavHostController, authViewModel: AuthViewModel) 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SignOutBar(userName: String, showSettings: Boolean, onSignOut: () -> Unit, onSettings: () -> Unit) {
+private fun TopBar(
+    userName:     String,
+    showSettings: Boolean,
+    onAlerts:     () -> Unit,
+    onSettings:   () -> Unit,
+    onSignOut:    () -> Unit
+) {
     TopAppBar(
         title   = { Text("Hey, $userName", style = MaterialTheme.typography.bodyMedium) },
         actions = {
-            if (showSettings) {
-                IconButton(onClick = onSettings) { Icon(Icons.Filled.Settings, "Settings") }
+            IconButton(onClick = onAlerts) {
+                Icon(Icons.Filled.Notifications, contentDescription = "Alerts")
             }
-            IconButton(onClick = onSignOut) { Icon(Icons.Filled.Logout, "Sign out") }
+            if (showSettings) {
+                IconButton(onClick = onSettings) {
+                    Icon(Icons.Filled.Settings, contentDescription = "Settings")
+                }
+            }
+            IconButton(onClick = onSignOut) {
+                Icon(Icons.Filled.Logout, contentDescription = "Sign out")
+            }
         }
     )
 }
@@ -95,7 +106,5 @@ private fun iconForRoute(route: String) = when (route) {
     AppRoute.Markets.route   -> Icons.Filled.ShowChart
     AppRoute.News.route      -> Icons.Filled.Article
     AppRoute.Watchlist.route -> Icons.Filled.Star
-    AppRoute.Alerts.route    -> Icons.Filled.Notifications
-    AppRoute.Signals.route   -> Icons.Filled.TrendingUp
     else                     -> Icons.Filled.Home
 }

--- a/app/src/main/java/com/example/marketlens/ui/news/NewsScreen.kt
+++ b/app/src/main/java/com/example/marketlens/ui/news/NewsScreen.kt
@@ -9,50 +9,135 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.marketlens.data.model.NewsArticle
+import com.example.marketlens.data.model.NewsSignal
+import com.example.marketlens.data.model.SignalStrength
 import com.example.marketlens.ui.components.ErrorView
 import com.example.marketlens.ui.components.LoadingView
+import com.example.marketlens.ui.theme.PriceDown
 import com.example.marketlens.ui.theme.PriceUp
 import com.example.marketlens.viewmodel.NewsViewModel
+import com.example.marketlens.viewmodel.SignalsViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+private enum class NewsTab { NEWS, SIGNALS }
+
 @Composable
-fun NewsScreen(viewModel: NewsViewModel = viewModel()) {
+fun NewsScreen(
+    newsViewModel:    NewsViewModel    = viewModel(),
+    signalsViewModel: SignalsViewModel = viewModel()
+) {
+    var selectedTab by remember { mutableStateOf(NewsTab.NEWS) }
+
+    Column(Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab.ordinal) {
+            Tab(
+                selected = selectedTab == NewsTab.NEWS,
+                onClick  = { selectedTab = NewsTab.NEWS },
+                text     = { Text("News") }
+            )
+            Tab(
+                selected = selectedTab == NewsTab.SIGNALS,
+                onClick  = { selectedTab = NewsTab.SIGNALS },
+                text     = { Text("Signals") }
+            )
+        }
+
+        AnimatedContent(
+            targetState  = selectedTab,
+            transitionSpec = { fadeIn(tween(250)) togetherWith fadeOut(tween(200)) },
+            label        = "news_tab_content",
+            modifier     = Modifier.fillMaxSize()
+        ) { tab ->
+            when (tab) {
+                NewsTab.NEWS    -> NewsContent(newsViewModel)
+                NewsTab.SIGNALS -> SignalsContent(signalsViewModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NewsContent(viewModel: NewsViewModel) {
     val state by viewModel.state.collectAsState()
 
-    AnimatedContent(
-        targetState = state,
-        transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(200)) },
-        label = "news_content"
-    ) { s ->
-        when {
-            s.isLoading -> LoadingView()
-            s.errorMessage != null -> ErrorView(message = s.errorMessage, onRetry = { viewModel.refresh() })
-            s.articles.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("No articles available", color = MaterialTheme.colorScheme.onSurfaceVariant)
+    when {
+        state.isLoading -> LoadingView()
+        state.errorMessage != null -> ErrorView(message = state.errorMessage!!, onRetry = { viewModel.refresh() })
+        state.articles.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No articles available", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        else -> Column(Modifier.fillMaxSize().padding(horizontal = 16.dp), Arrangement.spacedBy(12.dp)) {
+            Spacer(Modifier.height(8.dp))
+            Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween, Alignment.CenterVertically) {
+                Text("Market News", style = MaterialTheme.typography.titleLarge)
+                IconButton(onClick = { viewModel.refresh() }) { Icon(Icons.Filled.Refresh, "Refresh") }
             }
-            else -> Column(Modifier.fillMaxSize().padding(horizontal = 16.dp), Arrangement.spacedBy(12.dp)) {
-                Spacer(Modifier.height(4.dp))
-                Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween, Alignment.CenterVertically) {
-                    Text("Market News", style = MaterialTheme.typography.titleLarge)
-                    IconButton(onClick = { viewModel.refresh() }) { Icon(Icons.Filled.Refresh, "Refresh") }
+            LazyColumn(
+                Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                contentPadding = PaddingValues(bottom = 16.dp)
+            ) {
+                items(state.articles, key = { it.id }) { NewsCard(it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SignalsContent(viewModel: SignalsViewModel) {
+    val state by viewModel.state.collectAsState()
+
+    when {
+        state.isLoading -> LoadingView()
+        state.errorMessage != null -> ErrorView(message = state.errorMessage!!, onRetry = { viewModel.refresh() })
+        state.signals.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(32.dp)
+            ) {
+                Text("No signals yet", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "Signals are generated from news every 30 minutes.\nMake sure signals are enabled in Settings.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+        else -> Column(Modifier.fillMaxSize().padding(horizontal = 16.dp), Arrangement.spacedBy(12.dp)) {
+            Spacer(Modifier.height(8.dp))
+            Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween, Alignment.CenterVertically) {
+                Column {
+                    Text("Market Signals", style = MaterialTheme.typography.titleLarge)
+                    Text("Derived from news — informational only", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-                LazyColumn(
-                    Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                    contentPadding = PaddingValues(bottom = 16.dp)
-                ) {
-                    items(s.articles, key = { it.id }) { NewsCard(it) }
+                IconButton(onClick = { viewModel.refresh() }) { Icon(Icons.Filled.Refresh, "Refresh") }
+            }
+            LazyColumn(
+                Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                contentPadding = PaddingValues(bottom = 16.dp)
+            ) {
+                items(state.signals, key = { it.id }) { signal ->
+                    SignalCard(
+                        signal   = signal,
+                        onDelete = { viewModel.deleteSignal(signal.id) },
+                        onRead   = { viewModel.markRead(signal.id) }
+                    )
                 }
             }
         }
@@ -78,6 +163,56 @@ fun NewsCard(article: NewsArticle) {
                 Text(article.source, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text(formatTimestamp(article.publishedAt), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
+        }
+    }
+}
+
+@Composable
+private fun SignalCard(signal: NewsSignal, onDelete: () -> Unit, onRead: () -> Unit) {
+    val strengthColor = when (signal.strength) {
+        SignalStrength.HIGH   -> PriceDown
+        SignalStrength.MEDIUM -> Color(0xFFFFA726)
+        SignalStrength.LOW    -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val alpha = if (signal.isRead) 0.6f else 1f
+
+    Card(
+        onClick = { if (!signal.isRead) onRead() },
+        colors  = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(Modifier.fillMaxWidth().padding(14.dp), Arrangement.spacedBy(8.dp)) {
+            Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween, Alignment.Top) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.AutoMirrored.Filled.TrendingUp, null, tint = strengthColor.copy(alpha = alpha), modifier = Modifier.size(18.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Surface(color = strengthColor.copy(alpha = 0.15f), shape = MaterialTheme.shapes.small) {
+                            Text(signal.strength.name, modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                style = MaterialTheme.typography.labelSmall, color = strengthColor)
+                        }
+                        Surface(color = PriceUp.copy(alpha = 0.10f), shape = MaterialTheme.shapes.small) {
+                            Text(signal.sector, modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                style = MaterialTheme.typography.labelSmall, color = PriceUp)
+                        }
+                    }
+                }
+                IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Filled.Delete, "Delete", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(16.dp))
+                }
+            }
+            Text(signal.headline, style = MaterialTheme.typography.titleSmall, maxLines = 2, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha))
+            Text(signal.reason, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha))
+            if (signal.affectedSymbols.isNotEmpty()) {
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Text("Your watchlist:", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    signal.affectedSymbols.forEach { symbol ->
+                        Surface(color = MaterialTheme.colorScheme.surfaceVariant, shape = MaterialTheme.shapes.small) {
+                            Text(symbol, modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp), style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+            }
+            Text(SimpleDateFormat("MMM d, h:mm a", Locale.US).format(Date(signal.detectedAt)),
+                style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha))
         }
     }
 }


### PR DESCRIPTION
- Replace `SignOutBar` with `TopBar` in `AppScaffold`, adding a dedicated alerts action and simplifying navigation.
- Consolidate `News` and `Signals` into a single `NewsScreen` using a tabbed layout (`NewsTab.NEWS`, `NewsTab.SIGNALS`).
- Implement `SignalsContent` and `SignalCard` to display news-derived market insights, including strength levels, affected sectors, and watchlist symbols.
- Add support for signal-specific operations such as marking as read and deleting.
- Update bottom navigation to remove separate Alerts and Signals routes in favor of the new integrated layout.